### PR TITLE
Allow tile names for untiltiles.

### DIFF
--- a/src/xgrow.c
+++ b/src/xgrow.c
@@ -703,16 +703,44 @@ int parse_arg_line(char *arg, tube_params *params) {
       fsmax = atoi(&arg[6]);
    else if (IS_ARG_MATCH(arg, "untiltiles=")) {
       int i = 0;
+      int j = 0;
       char *pos;
-      pos = &arg[5];
+      char *name;
+
+      // Determine how many tiles are listed.
+      pos = &arg[10];
       while (pos != NULL) {
          pos = strchr(pos + 1, ',');
          params->present_list_len++;
+         fprintf(stderr, "+1\n");
       }
+
       params->present_list = (int *)malloc(params->present_list_len * sizeof(int));
-      pos = &arg[11];
+
+      // Now get the tiles
+      pos = &arg[10];
       while (pos != NULL) {
-         params->present_list[i++] = atoi(pos + 1);
+         i++;
+         params->present_list[i] = atoi(pos + 1);
+
+         if (params->present_list[i] == 0) {
+            // atoi returns a 0 if there was no number, and if the number was 0, that
+            // isn't a valid tile, so in that case, we'll try for a string tile name instead.
+            name = strtok(pos+1, ",\n\0");
+            for (j=1; j<N; j++) {
+               fprintf(stderr, "on: %d %s\n", j, name);
+               if (params->tile_names[j] == NULL) continue;
+               if (strcmp(name, params->tile_names[j]) == 0) {
+                  params->present_list[i] = j;
+                  fprintf(stderr, "Found tile %s for untiltiles.\n", name);
+                  break;
+               }
+            }
+            if (j == N) {
+               fprintf(stderr, "Did not find tile %s for untiltiles.\n", name);
+               exit(-1);
+            }
+         }
          pos = strchr(pos + 1, ',');
       }
       params->untiltiles = 1;

--- a/src/xgrow.c
+++ b/src/xgrow.c
@@ -712,36 +712,32 @@ int parse_arg_line(char *arg, tube_params *params) {
       while (pos != NULL) {
          pos = strchr(pos + 1, ',');
          params->present_list_len++;
-         fprintf(stderr, "+1\n");
       }
 
       params->present_list = (int *)malloc(params->present_list_len * sizeof(int));
 
       // Now get the tiles
-      pos = &arg[10];
-      while (pos != NULL) {
-         i++;
-         params->present_list[i] = atoi(pos + 1);
+      name = strtok(&arg[11], ",\n\0");
+      while (name != NULL) {
+         params->present_list[i] = atoi(name);
 
          if (params->present_list[i] == 0) {
             // atoi returns a 0 if there was no number, and if the number was 0, that
             // isn't a valid tile, so in that case, we'll try for a string tile name instead.
-            name = strtok(pos+1, ",\n\0");
-            for (j=1; j<N; j++) {
-               fprintf(stderr, "on: %d %s\n", j, name);
+            for (j=1; j<=N; j++) {
                if (params->tile_names[j] == NULL) continue;
                if (strcmp(name, params->tile_names[j]) == 0) {
                   params->present_list[i] = j;
-                  fprintf(stderr, "Found tile %s for untiltiles.\n", name);
                   break;
                }
             }
-            if (j == N) {
+            if (j == N + 1) {
                fprintf(stderr, "Did not find tile %s for untiltiles.\n", name);
                exit(-1);
             }
          }
-         pos = strchr(pos + 1, ',');
+         i++;
+         name = strtok(NULL, ",\n\0");
       }
       params->untiltiles = 1;
    } else if (IS_ARG_MATCH(arg, "untiltilescount=")) {

--- a/tests/test_xgrow_options.py
+++ b/tests/test_xgrow_options.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import pytest
+import glob
+from xgrow.parseoutput import XgrowOutput
+
+from xgrow.tileset import TileSet
+
+import numpy as np
+
+import xgrow
+
+
+def test_untiltiles():
+    ts = TileSet.from_yaml("examples/barish-perfect.yaml")
+
+    out: XgrowOutput = xgrow.run(
+        ts,
+        outputopts="array",
+        T=12,
+        untiltiles=["ZG", "ZE"],
+        size=128,
+        emax=1000,
+        window=False,
+        importfile="examples/tallrect.seed",
+    )
+    _, tilenums = ts.to_xgrow(return_tilenums=True)
+
+    assert np.any(out.tiles == tilenums["ZG"])
+    assert np.any(out.tiles == tilenums["ZE"])
+    assert out.data.tiles == 652

--- a/xgrow/CHANGELOG.md
+++ b/xgrow/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Current Git version
+
+- Untiltiles now also takes tile names (in C and Python), and can be entered as a list of strings (and ints) in Python.  There is now a test to ensure it keeps functioning properly as well.

--- a/xgrow/tileset.py
+++ b/xgrow/tileset.py
@@ -84,7 +84,8 @@ class XgrowArgs:
     seed: Optional[str] = None
     update_rate: Optional[int] = None
     tracefile: Optional[str] = None
-    untiltiles: Optional[str] = None
+    untiltiles: Optional[Sequence[Union[str, int]]] = None
+    "Run until the named or numbered tiles are present."
     tmax: Optional[float] = None
     emax: Optional[int] = None
     smax: Optional[int] = None

--- a/xgrow/tileset.py
+++ b/xgrow/tileset.py
@@ -529,6 +529,9 @@ class TileSet:
                     i1 = _get_or_int(tile_to_i, i1)
                     i2 = _get_or_int(tile_to_i, i2)
                     stream.write(f"vdoubletile={i1},{i2}\n")
+            elif isinstance(v, (list, tuple)):
+                v = ",".join(str(x) for x in v)
+                stream.write(f"{f}={v}\n")
             else:
                 stream.write(f"{f}={v}\n")
 


### PR DESCRIPTION
Using the tile name syntax of `<tilename>`, this makes the C and Python versions accept tile names for untiltiles= (but not untiltilescount=, yet).  It also tests the functionality of untiltiles= automatically.  The Python functions can now accept untiltiles as a list rather than a comma-separated string.